### PR TITLE
chore: disable browser launch in dev

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
       },
       "devDependencies": {
         "concurrently": "^8.2.0",
+        "cross-env": "^10.0.0",
         "electron": "^25.3.1",
         "electron-builder": "^24.4.0",
         "wait-on": "^7.0.1"
@@ -2608,6 +2609,13 @@
       "engines": {
         "node": ">= 10.0.0"
       }
+    },
+    "node_modules/@epic-web/invariant": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@epic-web/invariant/-/invariant-1.0.0.tgz",
+      "integrity": "sha512-lrTPqgvfFQtR/eY/qkIzp98OGdNJu0m5ji3q/nJI8v3SXkRKEnWiOxMmbvcSoAIzv/cGiuvRy57k4suKQSAdwA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.4.1",
@@ -7179,6 +7187,24 @@
       },
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/cross-env": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-10.0.0.tgz",
+      "integrity": "sha512-aU8qlEK/nHYtVuN4p7UQgAwVljzMg8hB4YK5ThRqD2l/ziSnryncPNn7bMLt5cFYsKVKBh8HqLqyCoTupEUu7Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@epic-web/invariant": "^1.0.0",
+        "cross-spawn": "^7.0.6"
+      },
+      "bin": {
+        "cross-env": "dist/bin/cross-env.js",
+        "cross-env-shell": "dist/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/cross-spawn": {

--- a/package.json
+++ b/package.json
@@ -5,9 +5,9 @@
   "main": "main.js",
   "scripts": {
     "start": "electron .",
-    "react-start": "react-scripts start",
+    "react-start": "cross-env BROWSER=none react-scripts start",
     "react-build": "react-scripts build",
-    "electron-dev": "concurrently \"npm run react-start\" \"wait-on http://localhost:3000 && electron .\"",
+    "electron-dev": "concurrently \"npm:react-start\" \"wait-on http://localhost:3000 && electron .\"",
     "clean": "node clean.js",
     "dist": "npm run clean && npm run react-build && electron-builder --win portable"
   },
@@ -25,7 +25,8 @@
     "concurrently": "^8.2.0",
     "electron": "^25.3.1",
     "electron-builder": "^24.4.0",
-    "wait-on": "^7.0.1"
+    "wait-on": "^7.0.1",
+    "cross-env": "^10.0.0"
   },
   "build": {
     "appId": "com.example.personal-invoice-manager",


### PR DESCRIPTION
## Summary
- prevent Create React App from opening a browser by default
- start React and Electron together without spawning a browser window

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6895551f9770832880f65622ecae8d7e