### PR TITLE
Ensure npm start launches React and Electron

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A desktop application to manage personal invoices",
   "main": "main.js",
   "scripts": {
-    "start": "electron .",
+    "start": "npm run electron-dev",
     "react-start": "cross-env BROWSER=none react-scripts start",
     "react-build": "react-scripts build",
     "electron-dev": "concurrently \"npm:react-start\" \"wait-on http://localhost:3000 && electron .\"",


### PR DESCRIPTION
## Summary
- Run React dev server and Electron together through `npm start`

## Testing
- `npm test` *(fails: Missing script 'test')*
- `npm run react-build`


------
https://chatgpt.com/codex/tasks/task_e_6895642062fc8328812cd6ddac627d5a